### PR TITLE
Improved past written portManipulator.c and main.c code

### DIFF
--- a/Unit/src/Header Files/portManipulator.h
+++ b/Unit/src/Header Files/portManipulator.h
@@ -1,8 +1,9 @@
+#include <avr/io.h>
+
 #ifndef PORTMANIPULATOR_H_
 #define PORTMANIPULATOR_H_
 
 int analogRead(int pin);
-
-void digitalWrite(char port, int mask, int value);
+void digitalWrite(volatile uint8_t *port, uint8_t mask, uint8_t value);
 
 #endif /* PORTMANIPULATOR_H_ */

--- a/Unit/src/Header Files/portManipulator.h
+++ b/Unit/src/Header Files/portManipulator.h
@@ -1,8 +1,10 @@
 #include <avr/io.h>
 
+
 #ifndef PORTMANIPULATOR_H_
 #define PORTMANIPULATOR_H_
 
+void initPortManipulator();
 int analogRead(int pin);
 void digitalWrite(volatile uint8_t *port, uint8_t mask, uint8_t value);
 

--- a/Unit/src/main.c
+++ b/Unit/src/main.c
@@ -6,23 +6,14 @@
 #include "UART.h"
 #include "sensors.h"
 #include "rollerShutter.h"
+#include "portManipulator.h"
 
 
 void setup(void) {
 	DDRB = 0xFF;
 	
 	initUART();
-	
-	
-	// Source: https://medium.com/@jrejaud/arduino-to-avr-c-reference-guide-7d113b4309f7
-	// 16Mhz / 128 = 125kHz ADC reference clock
-	ADCSRA |= ((1<<ADPS2)|(1<<ADPS1)|(1<<ADPS0));
-	
-	// Voltage reference from AVcc (5V on ATMega328p)
-	ADMUX |= (1<<REFS0);
-	
-	ADCSRA |= (1<<ADEN);	// Turn on ADC
-	ADCSRA |= (1<<ADSC);	// Do a preliminary conversion
+	initPortManipulator();
 	
 
 	_delay_ms(1000);

--- a/Unit/src/portManipulator.c
+++ b/Unit/src/portManipulator.c
@@ -1,6 +1,18 @@
 #include <avr/io.h>
 
 
+void initPortManipulator() {
+	// Source: https://medium.com/@jrejaud/arduino-to-avr-c-reference-guide-7d113b4309f7
+	// 16Mhz / 128 = 125kHz ADC reference clock
+	ADCSRA |= ((1<<ADPS2)|(1<<ADPS1)|(1<<ADPS0));
+	
+	// Voltage reference from AVcc (5V on ATMega328p)
+	ADMUX |= (1<<REFS0);
+	
+	ADCSRA |= (1<<ADEN);    // Turn on ADC
+	ADCSRA |= (1<<ADSC);    // Do a preliminary conversion
+}
+
 // Read analog pins
 int analogRead(uint8_t pin) {
 	// Source: https://medium.com/@jrejaud/arduino-to-avr-c-reference-guide-7d113b4309f7

--- a/Unit/src/portManipulator.c
+++ b/Unit/src/portManipulator.c
@@ -18,11 +18,6 @@ int analogRead(uint8_t pin) {
 }
 
 // Write to a set of masked pins
-void digitalWrite(char port, uint8_t mask, uint8_t value) {
-	if (port == 'B') {
-		PORTB = (PORTB & ~mask) | (value & mask);
-	}
-	else if (port == 'D') {
-		PORTD = (PORTD & ~mask) | (value & mask);
-	}
+void digitalWrite(volatile uint8_t *port, uint8_t mask, uint8_t value) {
+	*port = (*port & ~mask) | (value & mask);
 }

--- a/Unit/src/rollerShutter.c
+++ b/Unit/src/rollerShutter.c
@@ -27,9 +27,9 @@ void setRollerShutterStill() {
 
 void rollerShutterAnimate() {
 	if(animationActive == 1) {
-		digitalWrite('B', 0x0F, 0x02);
+		digitalWrite(&PORTB, 0x0F, 0x02);
 		_delay_ms(1000);
-		digitalWrite('B', 0x0F, 0x04);
+		digitalWrite(&PORTB, 0x0F, 0x04);
 		_delay_ms(1000);
 	}
 }


### PR DESCRIPTION
Improved digitalWrite function in portManipulator.c by getting rid of char parameter and replacing it with volatile unsigned int. You can now write to a digital port by passing &PORT as an argument.
Improved main.c by moving initialization for port manipulation to seperate function in portManipulator.c